### PR TITLE
fix(hub): persist and expose MCP entry_point for vicon

### DIFF
--- a/app/api/mcp-packages/[...id]/route.ts
+++ b/app/api/mcp-packages/[...id]/route.ts
@@ -233,6 +233,7 @@ export async function PUT(
     if (body.tags !== undefined) updateData.tags = body.tags
     if (body.tools !== undefined) updateData.tools = body.tools
     if (body.version !== undefined) updateData.version = body.version
+    if (body.entry_point !== undefined) updateData.entry_point = body.entry_point
     if (body.last_synced_at !== undefined) updateData.last_synced_at = body.last_synced_at
     if (body.status !== undefined) updateData.status = body.status
 

--- a/app/api/registry/route.ts
+++ b/app/api/registry/route.ts
@@ -57,6 +57,18 @@ const MOCK_PACKAGES: Record<string, {
     author: "ROSClaw Team",
     dependencies: ["unitree-sdk"],
   },
+  // Override until DB migration 004 is applied and the live record is synced.
+  "ros-claw/vicon-datastream-mcp": {
+    status: "success",
+    type: "mcp_server",
+    name: "ros-claw/vicon-datastream-mcp",
+    git_url: "https://github.com/ros-claw/vicon-datastream-mcp.git",
+    description: "Full-featured Vicon motion capture DataStream MCP server",
+    entry_point: "src/mcp_server.py",
+    version: "1.0.0",
+    author: "ROSClaw Team",
+    dependencies: ["mcp", "anyio", "uvicorn", "starlette"],
+  },
 };
 
 // Helper to create Supabase client

--- a/supabase/migrations/004_add_entry_point.sql
+++ b/supabase/migrations/004_add_entry_point.sql
@@ -1,0 +1,15 @@
+-- Add entry_point column to mcp_packages so the registry can return the
+-- correct server script path instead of always defaulting to server.py.
+
+alter table public.mcp_packages
+add column if not exists entry_point text default 'server.py';
+
+comment on column public.mcp_packages.entry_point
+  is 'Relative path to the MCP server entry point script (e.g. src/mcp_server.py)';
+
+-- Update the Vicon package to match its repository layout and version.
+update public.mcp_packages
+set entry_point = 'src/mcp_server.py',
+    version = '1.0.0',
+    updated_at = now()
+where name = 'ros-claw/vicon-datastream-mcp';


### PR DESCRIPTION
Add the missing `entry_point` column to `public.mcp_packages`, update the Vicon record to `src/mcp_server.py` / `1.0.0`, allow `entry_point` updates via the sync PUT endpoint, and add an in-code MOCK_PACKAGES override so the registry returns the correct metadata immediately.

🤖 Generated with [Claude Code](https://claude.com/claude-code)