### PR TITLE
fix(api): expose entryPoint in mcp-packages detail route

### DIFF
--- a/app/api/mcp-packages/[...id]/route.ts
+++ b/app/api/mcp-packages/[...id]/route.ts
@@ -95,6 +95,7 @@ export async function GET(
       category: data.category,
       robotType: data.robot_type,
       version: data.version,
+      entryPoint: data.entry_point || "server.py",
       downloadsCount: data.downloads_count,
       viewsCount: data.views_count || 0,
       githubStars: data.github_stars || 0,


### PR DESCRIPTION
Exposes the database `entry_point` value in `/api/mcp-packages/[...id]` so the Hub detail page (and direct API consumers) see the correct server script path instead of the default `server.py`.

Changes:
- Added `entryPoint: data.entry_point || "server.py"` to the GET response payload.